### PR TITLE
Refactor JupyterLab bootstrap

### DIFF
--- a/Vagrant-bootstrap-jupyterlab.sh
+++ b/Vagrant-bootstrap-jupyterlab.sh
@@ -3,7 +3,7 @@ set -euxo pipefail
 
 # NOTE: this bootstrap need to be execute as the vagrant user
 
-### user configuration
+### git configuration
 
 # CHANGEME if you wish to use a fork replace GITHUB_USERNAME with your username before provisioning,
 #  otherwise the main repo (https://github.com/jupyterlab/jupyterlab.git) will be used
@@ -14,29 +14,10 @@ export GITHUB_USERNAME="jupyterlab"
 export VM_USER=vagrant
 export VM_USER_HOME=/home/${VM_USER}
 
-### Set up a local development environment
-# see https://github.com/jupyterlab/jupyterlab/blob/master/docs/source/developer/contributing.rst#setting-up-a-local-development-environment
+### additional vagrant user configuration
 
-# only clone during the first provisioning
-if [[ ! -d jupyterlab ]]; then
-  git clone https://github.com/${GITHUB_USERNAME}/jupyterlab.git
-  cd jupyterlab
-else
-  cd jupyterlab
-  git pull --rebase
-fi
-
-export PATH="$HOME/.local/bin:$PATH"
-pip install -e ".[test]"
-jlpm install
-
-echo "Please wait, this will take some time ..."
-
-jlpm run build       # Build the dev mode assets (optional)
-jlpm run build:core  # Build the core mode assets (optional)
-jupyter lab build    # Build the app dir assets (optional)
-
-### final steps
+# write the instructions file, make so it is called after each login,
+# add a custom section to bashrc
 
 cat << EOF > /home/vagrant/instructions.txt
 See https://github.com/jupyterlab/jupyterlab/blob/master/docs/source/developer/contributing.rst#setting-up-a-local-development-environment
@@ -79,3 +60,29 @@ export ADDITIONAL_INSTRUCTIONS='echo; echo $PWD; echo; ls ; echo; cat $HOME/inst
 if ! grep -qFx "${COMMENT}" ${USER_RC_FILE}; then
   echo -e "\n${COMMENT}\n# ${ADDITIONAL_PATH}\n${ADDITIONAL_INSTRUCTIONS}" | tee -a ${USER_RC_FILE}
 fi
+
+### Set up a Jupyterlab local development environment
+# see https://github.com/jupyterlab/jupyterlab/blob/master/docs/source/developer/contributing.rst#setting-up-a-local-development-environment
+
+# only clone during the first provisioning
+if [[ ! -d jupyterlab ]]; then
+  git clone https://github.com/${GITHUB_USERNAME}/jupyterlab.git
+  cd jupyterlab
+else
+  cd jupyterlab
+  git pull --rebase
+fi
+
+export PATH="$HOME/.local/bin:$PATH"
+pip install -e ".[dev,test]"
+jlpm install
+
+echo
+echo "Please wait, this will take some time ..."
+
+jlpm run build       # Build the dev mode assets (optional)
+jlpm run build:core  # Build the core mode assets (optional)
+jupyter lab build    # Build the app dir assets (optional)
+
+echo
+echo "All done, the Jupyterlab local development environment is ready"


### PR DESCRIPTION
In this PR:
- rename the "user configuration" section to "git configuration"
- move the "vagrant user configuration" section up
- update the steps to install JupyterLab (see jupyterlab/jupyterlab#12606)

```
-          pip install -e .[test]
+          pip install -e .[dev,test]
```

which fixes the error:

```
» vagrant up 2>&1 | tee -a vagrant-up-$(date +%F).log
...

      Error: Cannot find module '/home/vagrant/jupyterlab/node_modules/fs-extra/lib/index.js'. Please verify that the package.json has a valid "main" entry
          at tryPackage (node:internal/modules/cjs/loader:363:19)
          at Module._findPath (node:internal/modules/cjs/loader:576:18)
          at Module._resolveFilename (node:internal/modules/cjs/loader:941:27)
          at Module._load (node:internal/modules/cjs/loader:803:27)
          at Module.require (node:internal/modules/cjs/loader:1021:19)
          at require (node:internal/modules/cjs/helpers:103:18)
          at Object.<anonymous> (/home/vagrant/jupyterlab/scripts/ensure-buildutils.js:8:12)
          at Module._compile (node:internal/modules/cjs/loader:1119:14)
          at Module._extensions..js (node:internal/modules/cjs/loader:1173:10)
          at Module.load (node:internal/modules/cjs/loader:997:32) {
        code: 'MODULE_NOT_FOUND',
        path: '/home/vagrant/jupyterlab/node_modules/fs-extra/package.json',
        requestPath: 'fs-extra'
      }
      
      Node.js v18.8.0
      npm notice
      npm notice New minor version of npm available! 8.18.0 -> 8.19.1
      npm notice Changelog: <https://github.com/npm/cli/releases/tag/v8.19.1>
      npm notice Run `npm install -g npm@8.19.1` to update!
      npm notice
      error Command failed with exit code 1.
      info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
      Traceback (most recent call last):
        File "/usr/local/lib/python3.9/dist-packages/pip/_vendor/pep517/in_process/_in_process.py", line 363, in <module>
          main()
        File "/usr/local/lib/python3.9/dist-packages/pip/_vendor/pep517/in_process/_in_process.py", line 345, in main
          json_out['return_val'] = hook(**hook_input['kwargs'])
        File "/usr/local/lib/python3.9/dist-packages/pip/_vendor/pep517/in_process/_in_process.py", line 283, in build_editable
          return hook(wheel_directory, config_settings, metadata_directory)
        File "/tmp/pip-build-env-kjbho2k_/overlay/lib/python3.9/site-packages/hatchling/build.py", line 101, in build_editable
          return os.path.basename(next(builder.build(wheel_directory, ['editable'])))
        File "/tmp/pip-build-env-kjbho2k_/overlay/lib/python3.9/site-packages/hatchling/builders/plugin/interface.py", line 136, in build
          build_hook.initialize(version, build_data)
        File "/tmp/pip-build-env-kjbho2k_/normal/lib/python3.9/site-packages/hatch_jupyter_builder/plugin.py", line 54, in initialize
          build_func(self.target_name, version, **build_kwargs)
        File "/home/vagrant/jupyterlab/buildapi.py", line 21, in builder
          npm_builder(target_name, version, *args, **kwargs)
        File "/tmp/pip-build-env-kjbho2k_/normal/lib/python3.9/site-packages/hatch_jupyter_builder/utils.py", line 116, in npm_builder
          run(npm_cmd + ["run", build_cmd], cwd=str(abs_path))
        File "/tmp/pip-build-env-kjbho2k_/normal/lib/python3.9/site-packages/hatch_jupyter_builder/utils.py", line 226, in run
          return subprocess.check_call(cmd, **kwargs)
        File "/usr/lib/python3.9/subprocess.py", line 373, in check_call
          raise CalledProcessError(retcode, cmd)
      subprocess.CalledProcessError: Command '['/usr/bin/node', 'jupyterlab/staging/yarn.js', 'run', 'build']' returned non-zero exit status 1.
      [end of output]
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
  ERROR: Failed building editable for jupyterlab
Failed to build jupyterlab
ERROR: Could not build wheels for jupyterlab, which is required to install pyproject.toml-based projects
```
